### PR TITLE
Move `usrcheat.dat` location out of extras folder

### DIFF
--- a/SD Card/sd/arm9/source/cheat.cpp
+++ b/SD Card/sd/arm9/source/cheat.cpp
@@ -55,7 +55,7 @@ bool CheatCodelist::parse(const std::string& aFileName)
 	if(romData(aFileName,gamecode,romcrc32))
 	{
 		// First try ntr-forwarder folder
-		FILE* dat=fopen("sd:/_nds/ntr-forwarder/extras/usrcheat.dat","rb");
+		FILE* dat=fopen("sd:/_nds/ntr-forwarder/usrcheat.dat","rb");
 		// If that fails, try TWiLight's file
 		if(!dat)
 			dat=fopen("sd:/_nds/TWiLightMenu/extras/usrcheat.dat","rb");
@@ -495,8 +495,8 @@ void CheatCodelist::onGenerate(void)
 {
 	FILE* db;
 	// Use ntr-forwarder folder if exists
-	if(access("sd:/_nds/ntr-forwarder/extras/usrcheat.dat", F_OK) == 0)
-		db=fopen("sd:/_nds/ntr-forwarder/extras/usrcheat.dat","r+b");
+	if(access("sd:/_nds/ntr-forwarder/usrcheat.dat", F_OK) == 0)
+		db=fopen("sd:/_nds/ntr-forwarder/usrcheat.dat","r+b");
 	else // use TWiLight's file
 		db=fopen("sd:/_nds/TWiLightMenu/extras/usrcheat.dat","r+b");
 

--- a/SD Card/sd/arm9/source/main.cpp
+++ b/SD Card/sd/arm9/source/main.cpp
@@ -551,7 +551,7 @@ int main(int argc, char **argv) {
 			if(codelist.romData(ndsPath, gameCode, crc32)) {
 				long cheatOffset; size_t cheatSize;
 				// First try ntr-forwarder folder
-				FILE* dat=fopen("sd:/_nds/ntr-forwarder/extras/usrcheat.dat","rb");
+				FILE* dat=fopen("sd:/_nds/ntr-forwarder/usrcheat.dat","rb");
 				// If that fails, try TWiLight's file
 				if(!dat)
 					dat=fopen("sd:/_nds/TWiLightMenu/extras/usrcheat.dat","rb");


### PR DESCRIPTION
I noticed the apfix files don't go in an `extras` folder when they're in `sd:/_nds/ntr-forwarder` but I had it check for usrcheat.dat in `sd:/_nds/ntr-forwarder/extras`, so this simply changes that to match.