### PR TITLE
Fix only using Widescreen.cxi from TWiLight folder

### DIFF
--- a/SD Card/sd/arm9/source/main.cpp
+++ b/SD Card/sd/arm9/source/main.cpp
@@ -317,7 +317,8 @@ void SetWidescreen(const char *filename, bool isHomebrew, const char *resetTid) 
 		if (access("sd:/luma/sysmodules/TwlBg.cxi", F_OK) == 0) {
 			rename("sd:/luma/sysmodules/TwlBg.cxi", "sd:/_nds/ntr-forwarder/TwlBg.cxi.bak");
 		}
-		if (rename("sd:/_nds/TWiLightMenu/TwlBg/Widescreen.cxi", "sd:/luma/sysmodules/TwlBg.cxi") == 0) {
+		if (rename("sd:/_nds/TWiLightMenu/TwlBg/Widescreen.cxi", "sd:/luma/sysmodules/TwlBg.cxi") == 0
+		 || rename("sd:/_nds/ntr-forwarder/Widescreen.cxi", "sd:/luma/sysmodules/TwlBg.cxi") == 0) {
 			CIniFile ntrforwarderini("sd:/_nds/ntr_forwarder.ini");
 			ntrforwarderini.SetInt("NTR-FORWARDER", "WIDESCREEN_LOADED", true);
 			ntrforwarderini.SaveIniFile("sd:/_nds/ntr_forwarder.ini");
@@ -423,11 +424,12 @@ void SetWidescreen(const char *filename, bool isHomebrew, const char *resetTid) 
 			fclose(file);
 		}
 	}
-	if (wideCheatFound && (access("sd:/_nds/TWiLightMenu/TwlBg/Widescreen.cxi", F_OK) == 0)) {
+	if (wideCheatFound && (access("sd:/_nds/TWiLightMenu/TwlBg/Widescreen.cxi", F_OK) == 0 || access("sd:/_nds/ntr-forwarder/Widescreen.cxi", F_OK) == 0)) {
 		if (access("sd:/luma/sysmodules/TwlBg.cxi", F_OK) == 0) {
-			rename("sd:/luma/sysmodules/TwlBg.cxi", "sd:/_nds/TWiLightMenu/TwlBg/TwlBg.cxi.bak");
+			rename("sd:/luma/sysmodules/TwlBg.cxi", (useTwlmPath ? "sd:/_nds/TWiLightMenu/TwlBg/TwlBg.cxi.bak" : "sd:/_nds/ntr-forwarder/TwlBg.cxi.bak"));
 		}
-		if (rename("sd:/_nds/TWiLightMenu/TwlBg/Widescreen.cxi", "sd:/luma/sysmodules/TwlBg.cxi") == 0) {
+		if (rename("sd:/_nds/TWiLightMenu/TwlBg/Widescreen.cxi", "sd:/luma/sysmodules/TwlBg.cxi") == 0
+		 || rename("sd:/_nds/ntr-forwarder/Widescreen.cxi", "sd:/luma/sysmodules/TwlBg.cxi") == 0) {
 			CIniFile ntrforwarderini("sd:/_nds/ntr_forwarder.ini");
 			ntrforwarderini.SetInt("NTR-FORWARDER", "WIDESCREEN_LOADED", true);
 			ntrforwarderini.SaveIniFile("sd:/_nds/ntr_forwarder.ini");
@@ -456,8 +458,8 @@ void UnsetWidescreen() {
 		iprintf("back to Widescreen.cxi\n");
 		for (int i = 0; i < 60*3; i++) swiWaitForVBlank();
 	}
-	if (access("sd:/_nds/ntr-forwarder/TwlBg.cxi.bak", F_OK) == 0) {
-		rename("sd:/_nds/ntr-forwarder/TwlBg.cxi.bak", "sd:/luma/sysmodules/TwlBg.cxi");
+	if (access(useTwlmPath ? "sd:/_nds/TWiLightMenu/TwlBg/TwlBg.cxi.bak" : "sd:/_nds/ntr-forwarder/TwlBg.cxi.bak", F_OK) == 0) {
+		rename(useTwlmPath ? "sd:/_nds/TWiLightMenu/TwlBg/TwlBg.cxi.bak" : "sd:/_nds/ntr-forwarder/TwlBg.cxi.bak", "sd:/luma/sysmodules/TwlBg.cxi");
 	}
 }
 


### PR DESCRIPTION
Whoops, somehow I didn't notice that it was completely ignoring `Widescreen.cxi` if it was in the nds-forwarder folder, now it should always check both spots.