### PR TITLE
change fcopy() success return value to fix bin format widescreen cheat code

### DIFF
--- a/SD Card/sd/arm9/source/fileCopy.cpp
+++ b/SD Card/sd/arm9/source/fileCopy.cpp
@@ -60,8 +60,7 @@ int fcopy(const char *sourcePath, const char *destinationPath)
 		if (offset > fsize) {
 			fclose(sourceFile);
 			fclose(destinationFile);
-			return 1;
-			break;
+			return 0;
 		}
 	}
 


### PR DESCRIPTION
the fcopy() function returns 1 after copy, but the SetWidescreen() function(the only consumer of fcopy) expects the return value to be 0, which makes the copy widescreen cheat code bin function always fail (the widescreen.pck version works because it uses fopen+fwrite, not fcopy). 

Change the success return value to 0 to make the bin format widescreen cheatcode work